### PR TITLE
bring custom deps into zingolabs

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -48,9 +48,9 @@ group = "0.8"
 
 rust-embed = { version = "5.1.0", features = ["debug-embed"] }
 
-zcash_primitives = { git = "https://github.com/adityapk00/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee", features = ["transparent-inputs"] }
-zcash_client_backend = { git = "https://github.com/adityapk00/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee"}
-zcash_proofs = { git = "https://github.com/adityapk00/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee", features = ["multicore"]}
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee", features = ["transparent-inputs"] }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee"}
+zcash_proofs = { git = "https://github.com/zingolabs/librustzcash", rev = "adeb3ec4ad15480482bc2962bc9fe453814db9ee", features = ["multicore"]}
 
 [dev-dependencies]
 portpicker = "0.1.0"


### PR DESCRIPTION
This updates an explicit dependecy to point into `zingolabs` so we can use our DAO-driven support systems (CI, etc.) to manage the system.