### PR TITLE
Add tarpaulin to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,25 +11,24 @@ jobs:
         os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name:                   Checkout repository
+        uses:                   actions/checkout@v2
+      - uses:                   actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
-          override: true
-          components: rustfmt, clippy
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
+          toolchain:            1.60.0
+          override:             true
+          components:           rustfmt, clippy
+      - name:                   Run keygen
+        run:                    ./keygen.sh
+      - name:                   Install Tarpaulin 
+        uses:                   actions-rs/cargo@v1
         with:
-          command: fetch
-      - name: Build 
-        uses: actions-rs/cargo@v1
+          command:              install
+          args:                 cargo-tarpaulin --verbose
+      - name:                   Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --all-features --workspace --timeout 300 --out Xml --avoid-cfg-tarpaulin
+      - name:                   Upload to codecov.io
+        uses:                   codecov/codecov-action@v2
         with:
-          command: build
-          args: --verbose --all
-      - name: Run keygen
-        run: ./keygen.sh
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all
+          fail_ci_if_error:     true


### PR DESCRIPTION
Uploads CI report to `codecov.io`, which I've hooked into zingolabs. 